### PR TITLE
Fix small error in schema.

### DIFF
--- a/data/primary-dataset.yml
+++ b/data/primary-dataset.yml
@@ -8,7 +8,6 @@ metrics:
 - id: AIS-05-M1 
   primaryControlId: AIS-05
   relatedControlIds:
-  - Missing
   metricDescription: This metric measures the percentage of running production code
     that passed static application security testing.
   expression:
@@ -37,7 +36,6 @@ metrics:
 - id: AIS-05-M2 
   primaryControlId: AIS-05
   relatedControlIds:
-  - Missing
   metricDescription: This metric measures the percentage of running production code
     that has been tested to show that it adheres to its desired behavior or specification.
   expression:
@@ -67,7 +65,6 @@ metrics:
 - id: AIS-05-M3 
   primaryControlId: AIS-05
   relatedControlIds:
-  - Missing
   metricDescription: This metric measures the percentage of running production 
     applications that have passed dynamic application security testing. 
   expression:

--- a/metrics-catalog.html
+++ b/metrics-catalog.html
@@ -104,7 +104,7 @@
 </head>
 <body>
 <h1>Continuous Audit Metrics Catalog, version 1.0.0</h1>
-<p>Generated on 2022-08-25 12:27:00 UTC</p>
+<p>Generated on 2022-08-31 14:07:38 UTC</p>
 <div>
 <p>This document has been automatically generated from the YAML source file at <a href="https://github.com/cloudsecurityalliance/continuous-audit-metrics/tree/main/data/primary-dataset.yml">https://github.com/cloudsecurityalliance/continuous-audit-metrics/tree/main/data/primary-dataset.yml</a></p>
 
@@ -208,7 +208,7 @@ security assurance and maintains compliance while enabling organizational speed
 of delivery goals. Automate when applicable and possible.
 </div>
 <div class="key green">Related CCMv4 Control IDs</div>
-<div class="value">Missing</div>
+<div class="value"></div>
 <div class="key orange">Metric ID</div>
 <div class="value"><strong>AIS-05-M1</strong></div>
 <div class="key orange">Metric Description</div>
@@ -260,7 +260,7 @@ security assurance and maintains compliance while enabling organizational speed
 of delivery goals. Automate when applicable and possible.
 </div>
 <div class="key green">Related CCMv4 Control IDs</div>
-<div class="value">Missing</div>
+<div class="value"></div>
 <div class="key orange">Metric ID</div>
 <div class="value"><strong>AIS-05-M2</strong></div>
 <div class="key orange">Metric Description</div>
@@ -309,7 +309,7 @@ security assurance and maintains compliance while enabling organizational speed
 of delivery goals. Automate when applicable and possible.
 </div>
 <div class="key green">Related CCMv4 Control IDs</div>
-<div class="value">Missing</div>
+<div class="value"></div>
 <div class="key orange">Metric ID</div>
 <div class="value"><strong>AIS-05-M3</strong></div>
 <div class="key orange">Metric Description</div>

--- a/tools/metrics_schema.yml
+++ b/tools/metrics_schema.yml
@@ -23,12 +23,10 @@ properties:
           type: string
           pattern: "^[A-Z&]{3}-[0-9]+$"
         relatedControlIds:
-          anyOf:
-            - type: array
-              items: 
-                type: string
-                pattern: "^[A-Z&]{3}-[0-9]+$"
-            - type: null
+          type: [ 'array', 'null' ]
+          items: 
+          - type: string
+            pattern: "^[A-Z&]{3}-[0-9]+$"
         metricDescription:
           type: string
         expression:
@@ -42,9 +40,7 @@ properties:
                 type: object
                 properties: 
                   id:
-                    anyOf:
-                      - type: string
-                      - type: null
+                    type: [ 'string', 'null' ]
                   name:
                     type: string
                   description:
@@ -61,9 +57,7 @@ properties:
             - formula
           additionalProperties: false
         rules: 
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: [ 'string', 'null' ]
         sloRecommendations:
           anyOf:
             - type: object


### PR DESCRIPTION
This is a minor fix to the schema. The `relatedControlIds` accepted malformed entries, such as the word 'Missing'. This is now dissallowed.