### PR TITLE
Limit automated actions to verifying html (no auto-commit of autogenerated html) 

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -25,9 +25,12 @@ jobs:
       - name: Generate metrics-catalog.html
         working-directory: tools
         run: ruby metrics_validator.rb ../data/primary-dataset.yml ../data/front-matter.md ../metrics-catalog.html
-      - name: Push metrics-catalog.html to the repo
-        uses: test-room-7/action-update-file@v1
-        with:
-          file-path: metrics-catalog.html
-          commit-msg: Automtaed update of metrics-catalog.html
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+# current permissions block actions updating files
+# TODO: consider https://github.com/marketplace/actions/create-pull-request instead
+# (which also requires permissions)
+#      - name: Push metrics-catalog.html to the repo
+#        uses: test-room-7/action-update-file@v1
+#        with:
+#          file-path: metrics-catalog.html
+#          commit-msg: Automtaed update of metrics-catalog.html
+#          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/metrics-catalog.html
+++ b/metrics-catalog.html
@@ -104,7 +104,7 @@
 </head>
 <body>
 <h1>Continuous Audit Metrics Catalog, version 1.0.0</h1>
-<p>Generated on 2022-08-25 12:27:00 UTC</p>
+<p>Generated on 2022-09-07 22:53:30 UTC</p>
 <div>
 <p>This document has been automatically generated from the YAML source file at <a href="https://github.com/cloudsecurityalliance/continuous-audit-metrics/tree/main/data/primary-dataset.yml">https://github.com/cloudsecurityalliance/continuous-audit-metrics/tree/main/data/primary-dataset.yml</a></p>
 

--- a/metrics-catalog.html
+++ b/metrics-catalog.html
@@ -104,7 +104,7 @@
 </head>
 <body>
 <h1>Continuous Audit Metrics Catalog, version 1.0.0</h1>
-<p>Generated on 2022-09-07 22:53:30 UTC</p>
+<p>Generated on 2022-09-07 22:55:05 UTC</p>
 <div>
 <p>This document has been automatically generated from the YAML source file at <a href="https://github.com/cloudsecurityalliance/continuous-audit-metrics/tree/main/data/primary-dataset.yml">https://github.com/cloudsecurityalliance/continuous-audit-metrics/tree/main/data/primary-dataset.yml</a></p>
 


### PR DESCRIPTION
until we decide to update the permissions in the main repository we can't auto-generate the html in place. This commit changes the action to run the verify operations but not push the generated html automaticaly.

It also commits an updated copy of the generated html. 

The comments suggest "consider https://github.com/marketplace/actions/create-pull-request instead".