### PR TITLE
Initial JSON schema for yaml

### DIFF
--- a/data/primary-dataset.yml
+++ b/data/primary-dataset.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../tools/primary-dataset.schema.json
 ---
 name: Continuous Audit Metrics Catalog
 version: 1.0.0
@@ -1313,9 +1314,7 @@ ccm_references:
     at all of the CSP's sites within a secured system.
 - id: DSP-04
   title: Data Classification
-  specification: 'Classify data according to its type and sensitivity level.
-
-'
+  specification: 'Classify data according to its type and sensitivity level.'
 - id: DSP-05
   title: Data Flow Documentation
   specification: |
@@ -1382,9 +1381,7 @@ ccm_references:
     and provide immediate notification to the accountable party.
 - id: SEF-05
   title: Incident Response Metrics
-  specification: 'Establish and monitor information security incident metrics.
-
-'
+  specification: 'Establish and monitor information security incident metrics.'
 - id: SEF-06
   title: Event Triage Processes
   specification: |
@@ -1392,9 +1389,7 @@ ccm_references:
     measures supporting business processes to triage security-related events.
 - id: STA-07
   title: Supply Chain Inventory
-  specification: 'Develop and maintain an inventory of all supply chain relationships.
-
-'
+  specification: 'Develop and maintain an inventory of all supply chain relationships.'
 - id: TVM-03
   title: Vulnerability Remediation Schedule
   specification: |

--- a/tools/primary-dataset.schema.json
+++ b/tools/primary-dataset.schema.json
@@ -1,0 +1,186 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/CSACAM",
+    "definitions": {
+        "CSACAM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "https"
+                    ]
+                },
+                "ccm_version": {
+                    "type": "string"
+                },
+                "copyright": {
+                    "type": "string"
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Metric"
+                    }
+                },
+                "ccm_references": {
+                    "type": "array", 
+                    "items": {
+                        "$ref": "#/definitions/ccm_reference"
+                    }
+                }
+            },
+            "required": [
+                "ccm_version",
+                "copyright",
+                "metrics",
+                "name",
+                "url",
+                "version"
+            ]
+        },
+        "Metric": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "primaryControlId": {
+                    "type": "string"
+                },
+                "relatedControlIds": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "metricDescription": {
+                    "type": "string"
+                },
+                "expression": {
+                    "$ref": "#/definitions/Expression"
+                },
+                "rules": {
+                    "type": "string",
+                    "description": "rules that MUST be followed to perform a measurement"
+                },
+                "sloRecommendations": {
+                    "$ref": "#/definitions/sloRecommendations"
+                },
+                "implementationGuidelines": {
+                    "type": "string"
+                },
+                "auditGuidelines": {
+                    "type": "string"
+                },
+                "samplingPeriod": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "expression",
+                "id",
+                "implementationGuidelines",
+                "metricDescription",
+                "primaryControlId",
+                "relatedControlIds",
+                "rules",
+                "sloRecommendations"
+            ]
+        },
+        "ccm_reference": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "specification": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "specification",
+                "title"
+            ]
+        },
+        "Expression": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formula": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Parameter"
+                    }
+                }
+            },
+            "required": [
+                "formula",
+                "parameters"
+            ]
+        },
+        "Parameter": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "description",
+                "id",
+                "name"
+            ]
+        },
+        "sloRecommendations": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "sloRangeMin": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "sloRangeMin"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
The start of a proper JSON schema to track the requirements described in the wiki and embedded in the HTML generation code. This is just a first pass. Although the schema is defined its very accepting of loose yaml (missing values are accepted, no regex's are defined etc). 

Different editors or schema validators handle this different ways but 'visual studio code' w/ the "YAML Language Support by Red Hat" extension will use the common inserted into the top of the yaml file and use it to apply the appropriate schema file. As documented in https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml

Other editors or yaml validators will have similar systems. Some of which we could apply during 'action' validation. 

Additional changes: A few strings in the yaml file have extra newlines. This passes yaml linter but does throw some yaml tooling like the above redhat extension for a loop. I've fixed those strings to better see the value of the JSON schema. 