### PR TITLE
Update actions.yaml to fix ruby and upload artifact

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.6'
       - name: Prepare the ruby environment
@@ -25,6 +25,13 @@ jobs:
       - name: Generate metrics-catalog.html
         working-directory: tools
         run: ruby metrics_validator.rb ../data/primary-dataset.yml ../data/front-matter.md ../metrics-catalog.html
+      - uses: actions/upload-artifact@v3
+        with:
+          name: metrics-catalog.html
+          path: metrics-catalog.html
+          retention-days: 5
+          # the metrics-catalog.html file can now be downloaded in the github UI, see docs for more info:
+          # https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts
 # current permissions block actions updating files
 # TODO: consider https://github.com/marketplace/actions/create-pull-request instead
 # (which also requires permissions)


### PR DESCRIPTION
The 'autogenerate metrics-catalog.html' action has been failing for a while now. The problem was that actions/setup-ruby is deprecated and we're supposed to use ruby/setup-ruby instead. I've made that change.

Also for a while now the generated html has been thrown away - this is because of permissions changes that were made a while back that limit us from committing files from the actions. (Attackers were able to use this, if they could access the actions, to push code into the repository. bad business!). The comments provide a way for automatically creating a PR but the owner of cloudsecurityalliance/continuous-audit-metrics would need to set the permissions and drive that. What I've done instead here is use actions/upload-artifact to make the generated html available via the github UI. That will let us manually download the generated file and check it in if we want. 