### PR TITLE
removed editorial note

### DIFF
--- a/data/primary-dataset.yml
+++ b/data/primary-dataset.yml
@@ -1254,7 +1254,7 @@ metrics:
         name: NumHosts
         description: Number of hosts protected by the organizations standard anti-malware solution
   sloRecommendations:
-    sloRangeMin: 99% [action item: talk to some vendors and get their recommendation]. Check CIS benchmarks or DoD in search of some guidelines. 
+    sloRangeMin: 99% 
 - id: BCR-08-M1
   primaryControlId: BCR-08
   relatedControlIds:


### PR DESCRIPTION
Previous PR #78 broke the build... the editorial comment to continue the discussion in Issue #75 about the best SLO was left in the code. (See comments in the thread). This PR removes the editorial note and means we need to track issues in actual issues. 