### PR TITLE
DCS-06-M2 to measure effectiveness ("ownership") 

### DIFF
--- a/data/primary-dataset.yml
+++ b/data/primary-dataset.yml
@@ -449,7 +449,6 @@ metrics:
 - id: DCS-06-M2
   primaryControlId: DCS-06
   relatedControlIds:
-  - ISO270002 A.8.1.2
   metricDescription: This metric measures the ratio of owned assets in the inventory to the total assets in the inventory. The goal is to ensure that all assets in the inventory are owned.
   expression:
     formula: "(A/B)*100"

--- a/data/primary-dataset.yml
+++ b/data/primary-dataset.yml
@@ -446,6 +446,27 @@ metrics:
     intended to ensure the coverage is accurate and inclusive of 3rd party CSPs where
     the  organization is responsible for the controls.
   samplingPeriod: P1D
+- id: DCS-06-M2
+  primaryControlId: DCS-06
+  relatedControlIds:
+  - ISO270002 A.8.1.2
+  metricDescription: This metric measures the ratio of owned assets in the inventory to the total assets in the inventory. The goal is to ensure that all assets in the inventory are owned.
+  expression:
+    formula: "(A/B)*100"
+    parameters:
+    - id: 
+      name: A
+      description: Number of assets in the inventory that are owned
+    - id: 
+      name: B
+      description: Total number of assets in the inventory
+  rules: The assumption is that the design of the DCS-06 control process(es) was found
+    to be effective by internal or external audits. All assets shall be owned according to the ISO 27002 control A.8.1.2.
+  sloRecommendations:
+    sloRangeMin: 100%
+  implementationGuidelines: This relies on the asset inventory as defined in
+    CCMv4 DCS-06. All assets should be owned and tracked as part of the asset inventory. Any asset that is not owned raises potential operational risks and should be investigated. Assets include both physical and logical entities, including third-party services and microservices where control responsibilities lie with the organization. Ownership should be clearly defined for each asset in the inventory, with appropriate documentation and tracking measures in place.
+  samplingPeriod: P1D
 - id: DSP-04-M2
   primaryControlId: DSP-04
   relatedControlIds:


### PR DESCRIPTION
DCS-06-M1 works to ensure the number of distinct assets seen in the security audit logs are in the inventory. But the resulting metric only tells us that there is an inventory entry. Not that the entry is useful or "effective".

This submission for DCS-06-M2 provides a measure of effectiveness in that each item in the inventory has an 'owner'. The actual definition of ownership is left up to the organization (so this could be a person, a group, or a ticketing system that has its own ownership path). Still, this ensures that for any item in a environment that is implicated in an incident or fails a scan or whatever -- the organization has a path to contact _somebody_ to fix it. That is undeniably more mature than just that they have an inventory, of potentially empty data records, that mirrors the deployment. 